### PR TITLE
set pointer-events of button children to none, removed outline on dropdown toggle button

### DIFF
--- a/src/sass/mui/_buttons.scss
+++ b/src/sass/mui/_buttons.scss
@@ -80,6 +80,11 @@ $btn-box-shadow-active: inset 0 3px 5px rgba(mui-color('black'), .125);
     font-size: 1.3rem;
     line-height: inherit;
   }
+
+  // ignore clicks on child elements
+  * {
+    pointer-events: none;
+  }
 }
 
 

--- a/src/sass/mui/_dropdowns.scss
+++ b/src/sass/mui/_dropdowns.scss
@@ -1,11 +1,11 @@
 // Dropdown wrapper
 .#{$prfx}dropdown {
   position: relative;
-}
 
-// Prevent focus on dropdown toggle when closing dropdowns
-.#{$prfx}dropdown-toggle:focus {
-  outline: 0;
+  // prevent focus when dropdown is open
+  [data-toggle="dropdown"]:focus {
+    outline: 0;
+  }
 }
 
 // The dropdown menu (ul)


### PR DESCRIPTION
Set pointer-events to none in button children elements as a solution to the problem of ignored clicks inside buttons.